### PR TITLE
feat: implement server-side pagination for WTM mode

### DIFF
--- a/config/products-package.php
+++ b/config/products-package.php
@@ -56,7 +56,7 @@ return [
     | Configure default pagination settings.
     |
     */
-    'per_page' => env('PRODUCT_PACKAGE_PER_PAGE', 15),
+    'per_page' => env('PRODUCT_PACKAGE_PER_PAGE', 25),
     'max_per_page' => env('PRODUCT_PACKAGE_MAX_PER_PAGE', 100),
 
     /*

--- a/src/Http/Traits/ProductRequestHelpers.php
+++ b/src/Http/Traits/ProductRequestHelpers.php
@@ -51,13 +51,13 @@ trait ProductRequestHelpers
      */
     public function getPagination()
     {
-        $perPage = (int) $this->get('per_page', config('shopsync.per_page', 15));
+        $perPage = (int) $this->get('per_page', config('products-package.per_page', 25));
         $perPage = min($perPage, 100); // Max 100 items per page
 
         return [
             'per_page' => $perPage,
             'page' => (int) $this->get('page', 1),
-            'paginate' => $this->has('page')
+            'paginate' => true
         ];
     }
 

--- a/src/Models/Attribute.php
+++ b/src/Models/Attribute.php
@@ -198,6 +198,9 @@ class Attribute extends Model
      */
     public function getProductsCountAttribute(): int
     {
+        if (config('products-package.mode') === 'wtm') {
+            return $this->attributes['products_count'] ?? 0;
+        }
         return $this->products()->count();
     }
 }

--- a/src/Models/Brand.php
+++ b/src/Models/Brand.php
@@ -73,6 +73,9 @@ class Brand extends Model
      */
     public function getProductsCountAttribute(): int
     {
+        if (config('products-package.mode') === 'wtm') {
+            return $this->attributes['products_count'] ?? 0;
+        }
         return $this->products()->count();
     }
 
@@ -81,6 +84,9 @@ class Brand extends Model
      */
     public function getActiveProductsCountAttribute(): int
     {
+        if (config('products-package.mode') === 'wtm') {
+            return $this->attributes['active_products_count'] ?? 0;
+        }
         return $this->activeProducts()->count();
     }
 

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -137,6 +137,9 @@ class Category extends Model
      */
     public function getProductsCountAttribute(): int
     {
+        if (config('products-package.mode') === 'wtm') {
+            return $this->attributes['products_count'] ?? 0;
+        }
         return $this->products()->count();
     }
 
@@ -145,6 +148,9 @@ class Category extends Model
      */
     public function getActiveProductsCountAttribute(): int
     {
+        if (config('products-package.mode') === 'wtm') {
+            return $this->attributes['active_products_count'] ?? 0;
+        }
         return $this->activeProducts()->count();
     }
 }

--- a/src/Models/Location.php
+++ b/src/Models/Location.php
@@ -97,6 +97,9 @@ class Location extends Model
      */
     public function getProductsCountAttribute(): int
     {
+        if (config('products-package.mode') === 'wtm') {
+            return $this->attributes['products_count'] ?? 0;
+        }
         return $this->products()->count();
     }
 
@@ -105,6 +108,9 @@ class Location extends Model
      */
     public function getActiveProductsCountAttribute(): int
     {
+        if (config('products-package.mode') === 'wtm') {
+            return $this->attributes['active_products_count'] ?? 0;
+        }
         return $this->activeProducts()->count();
     }
 

--- a/src/Models/Supplier.php
+++ b/src/Models/Supplier.php
@@ -89,6 +89,9 @@ class Supplier extends Model
      */
     public function getProductsCountAttribute(): int
     {
+        if (config('products-package.mode') === 'wtm') {
+            return $this->attributes['products_count'] ?? 0;
+        }
         return $this->products()->count();
     }
 
@@ -97,6 +100,9 @@ class Supplier extends Model
      */
     public function getActiveProductsCountAttribute(): int
     {
+        if (config('products-package.mode') === 'wtm') {
+            return $this->attributes['active_products_count'] ?? 0;
+        }
         return $this->activeProducts()->count();
     }
 

--- a/src/Services/ProductFetchers/DatabaseProductFetcher.php
+++ b/src/Services/ProductFetchers/DatabaseProductFetcher.php
@@ -14,7 +14,7 @@ class DatabaseProductFetcher implements ProductFetcherInterface
         return $this->buildQuery($filters, $includes)->get();
     }
 
-    public function paginate(int $perPage = 15, array $filters = [], array $includes = [])
+    public function paginate(int $perPage = 25, array $filters = [], array $includes = [])
     {
         return $this->buildQuery($filters, $includes)->paginate($perPage);
     }

--- a/src/Transformers/JsonApiTransformer.php
+++ b/src/Transformers/JsonApiTransformer.php
@@ -184,7 +184,7 @@ class JsonApiTransformer
         $related = $model->getRelation($relationshipName);
         
         if ($related === null) {
-            return ['data' => null];
+            return ['data' => []];
         }
         
         if ($related instanceof Collection || is_array($related)) {


### PR DESCRIPTION
  - Changed WTM mode from client-side to server-side pagination
  - ApiProductFetcher now sends page and per_page parameters to API
  - Removed client-side data slicing in favor of API pagination
  - Ensured WTM mode doesn't query database directly
  - Updated pagination to always be enabled for consistent API behavior
  - Added pagination support for both list and search endpoints
  - Single item endpoints (show) remain without pagination

  BREAKING CHANGE: WTM mode now requires API to support pagination parameters